### PR TITLE
WatchPos GuardClause - Observers running before ready

### DIFF
--- a/geo-location.html
+++ b/geo-location.html
@@ -151,6 +151,12 @@ Provides the current location using the [Geolocation API](https://developer.mozi
       },
 
       fetch: function () {
+        // Guard clause in case observer runs before element is ready. Refer to Polymer issue #3438
+        // https://github.com/Polymer/polymer/issues/3438
+        if (this.idle === undefined || this.watchPos === undefined) {
+          return;
+        }
+
         if (fetching_) {
           return;
         }


### PR DESCRIPTION
WatchPos functionality is not currently working, due to the observer being called before the ready function.
fetch() is being called by idle observer and by watchPos observer before being run by the ready() function. During the first run of fetch(), watchPos is still undefined, making the watch_ variable null.

It's my understanding that observers should not run before the element is ready. There is currently an [issue](http://github.com/Polymer/polymer/issues/3438) open in the polymer project about this subject. 