### PR TITLE
<geo-location> initial request is always with low accuracy, not cache…

### DIFF
--- a/geo-location.html
+++ b/geo-location.html
@@ -153,7 +153,7 @@ Provides the current location using the [Geolocation API](https://developer.mozi
       fetch: function () {
         // Guard clause in case observer runs before element is ready. Refer to Polymer issue #3438
         // https://github.com/Polymer/polymer/issues/3438
-        if (this.idle === undefined || this.watchPos === undefined) {
+        if (this.idle === undefined || this.watchPos === undefined || this.highAccuracy === undefined || this.timeout === undefined || this.maximumAge === undefined) {
           return;
         }
 


### PR DESCRIPTION
…d and with wrong timeout. All attributes are ignored.


When having attributes like so: 
```
<geo-location maximum-age="30000" high-accuracy="true" ></geo-location>
```
like **maximum-age** or **high-accuracy** every initial request ignores those attributes; 

The Guard placed in fetch method is not sufficient to ensure the element is ready:
```
fetch: function () {
        // Guard clause in case observer runs before element is ready. Refer to Polymer issue #3438
        // https://github.com/Polymer/polymer/issues/3438
        if (this.idle === undefined || this.watchPos === undefined) {
          return;
        }
```
The fetch method (observer) is called twice - for each default value of **this.idle** and **this.watchPos**
```
idle: {
    type: Boolean,
    value: false,
    observer: 'fetch'
},
watchPos: {
    type: Boolean,
    value: false,
    observer: 'fetch'
}
```
but when **this.idle** and **this.watchPos** are set - the element is still not ready and none of the attributes are available , and fetch is executed with options like: 
```
Object {enableHighAccuracy: undefined, timeout: undefined, maximumAge: undefined}
```

This causes maximum-age to not cache the location the first time, the first location is not accurate since the high-accuracy is not true and all sorts of problems on mobile device as well as performance issues. 

A simple fix that is working for me is to add the 3 attributes to the list like so: 
```
if (this.idle === undefined || this.watchPos === undefined || this.highAccuracy === undefined || this.timeout === undefined || this.maximumAge === undefined) {
          return;
        }
```