### PR TITLE
Fetch method called twice on change of some attributes

### DIFF
--- a/geo-location.html
+++ b/geo-location.html
@@ -72,8 +72,7 @@ Provides the current location using the [Geolocation API](https://developer.mozi
          */
         idle: {
           type: Boolean,
-          value: false,
-          observer: 'fetch'
+          value: false
         },
 
         /**
@@ -82,8 +81,7 @@ Provides the current location using the [Geolocation API](https://developer.mozi
          */
         watchPos: {
           type: Boolean,
-          value: false,
-          observer: 'fetch'
+          value: false
         },
 
         /**


### PR DESCRIPTION
having `observers: [ 'fetch(idle, watchPos, highAccuracy, timeout, maximumAge)'] ` we don't need `idle` and `watchPos` properties specific observers. 

E.g. Changing watchPos will execute twice the fetch method.