### PR TITLE
Add `apiSupported` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Geolocation API Polymer web component.
 
-Example to get the device geolocation values:
+Get once and display the device geolocation values and whether Geolocation API is supported or not:
 <!---
 ```
 <custom-element-demo>
@@ -23,9 +23,10 @@ Example to get the device geolocation values:
 ```
 -->
 ```html
-<geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+<geo-location api-supported="{{apiSupported}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
 
 <ul>
+  <li>API supported: [[apiSupported]]</li>
   <li>Latitude: [[latitude]]</li>
   <li>Longitude: [[longitude]]</li>
 </ul>

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,12 @@
 {
   "name": "geo-location",
-  "version": "2.0.0",
   "description": "Geolocation API Polymer web component",
   "keywords": [
     "web-component",
+    "polymer-element",
     "polymer",
+    "polymer-2",
+    "polymer-2-hybrid",
     "device",
     "geolocation",
     "geo",

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,14 +25,15 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
-      <h3>Get the device geolocation values</h3>
+      <h3>Get once and display the device geolocation values and whether Geolocation API is supported or not</h3>
       <demo-snippet>
         <template>
           <dom-bind>
             <template is="dom-bind">
-              <geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+              <geo-location api-supported="{{apiSupported}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
 
               <ul>
+                <li>API supported: [[apiSupported]]</li>
                 <li>Latitude: [[latitude]]</li>
                 <li>Longitude: [[longitude]]</li>
               </ul>

--- a/geo-location.html
+++ b/geo-location.html
@@ -7,10 +7,16 @@
 <!--
 Geolocation API Polymer web component.
 
-Example to get the device geolocation values:
+Get once and display the device geolocation values and whether Geolocation API is supported or not:
 
 ```html
-<geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+<geo-location api-supported="{{apiSupported}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+
+<ul>
+  <li>API supported: [[apiSupported]]</li>
+  <li>Latitude: [[latitude]]</li>
+  <li>Longitude: [[longitude]]</li>
+</ul>
 ```
 
 Continuous update the device geolocation values with high accuracy, and center Google Maps map and marker to the current location:
@@ -37,6 +43,16 @@ TODO: change the API key to your own.
     },
 
     properties: {
+      /**
+       * Indicates whether `Geolocation API` is supported or not.
+       */
+      apiSupported: {
+        type: Boolean,
+        readOnly: true,
+        notify: true,
+        value: 'geolocation' in navigator
+      },
+
       /**
        * The latitude of the current position.
        */


### PR DESCRIPTION
* Add `apiSupported` property that indicates whether Geolocation API is supported or not.
* Update code and descriptions of samples in `geo-location.html`, `demo/index.html` and `README.md` files.
* Remove `version` field in `bower.json` file, because it's deprecated and ignored by Bower (https://github.com/bower/spec/blob/master/json.md#version).
* Add `polymer-element`, `polymer-2` and `polymer-2-hybrid` keywords to `bower.json` file to indicate that this is Polymer 1.x/2.x hybrid element.