### PR TITLE
Add `permissionStatus` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Geolocation API Polymer web component.
 
-Get once and display the device geolocation values and continuous update the Gelocation API permission status:
+Get once and display the device geolocation values and continuous update the Geolocation API permission status:
 <!---
 ```
 <custom-element-demo>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Geolocation API Polymer web component.
 
-Example to get the device geolocation values:
+Get once and display the device geolocation values and continuous update the Gelocation API permission status:
 <!---
 ```
 <custom-element-demo>
@@ -23,9 +23,10 @@ Example to get the device geolocation values:
 ```
 -->
 ```html
-<geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+<geo-location permission-status="{{permissionStatus}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
 
 <ul>
+  <li>Permission status: [[permissionStatus]]</li>
   <li>Latitude: [[latitude]]</li>
   <li>Longitude: [[longitude]]</li>
 </ul>

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,8 @@
     "location",
     "position",
     "navigation",
+    "api",
+    "permission",
     "coordinates",
     "latitude",
     "longitude",

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
-      <h3>Get once and display the device geolocation values and continuous update the Gelocation API permission status</h3>
+      <h3>Get once and display the device geolocation values and continuous update the Geolocation API permission status</h3>
       <demo-snippet>
         <template>
           <dom-bind>

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,14 +25,15 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
-      <h3>Get the device geolocation values</h3>
+      <h3>Get once and display the device geolocation values and continuous update the Gelocation API permission status</h3>
       <demo-snippet>
         <template>
           <dom-bind>
             <template is="dom-bind">
-              <geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+              <geo-location permission-status="{{permissionStatus}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
 
               <ul>
+                <li>Permission status: [[permissionStatus]]</li>
                 <li>Latitude: [[latitude]]</li>
                 <li>Longitude: [[longitude]]</li>
               </ul>

--- a/geo-location.html
+++ b/geo-location.html
@@ -7,7 +7,7 @@
 <!--
 Geolocation API Polymer web component.
 
-Get once and display the device geolocation values and continuous update the Gelocation API permission status:
+Get once and display the device geolocation values and continuous update the Geolocation API permission status:
 
 ```html
 <geo-location permission-status="{{permissionStatus}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
@@ -91,7 +91,7 @@ TODO: change the API key to your own.
       },
 
       /**
-       * The maximumAge option in the Gelocation API.
+       * The maximumAge option in the Geolocation API.
        */
       maximumAge: {
         type: Number,
@@ -99,7 +99,7 @@ TODO: change the API key to your own.
       },
 
       /**
-       * The timeout option in the Gelocation API.
+       * The timeout option in the Geolocation API.
        */
       timeout: {
         type: Number,
@@ -117,7 +117,7 @@ TODO: change the API key to your own.
       },
 
       /**
-       * [Status](https://w3c.github.io/permissions/#status-of-a-permission) of Gelocation API permission.
+       * [Status](https://w3c.github.io/permissions/#status-of-a-permission) of Geolocation API permission.
        */
       permissionStatus: {
         type: String,

--- a/geo-location.html
+++ b/geo-location.html
@@ -7,10 +7,16 @@
 <!--
 Geolocation API Polymer web component.
 
-Example to get the device geolocation values:
+Get once and display the device geolocation values and continuous update the Gelocation API permission status:
 
 ```html
-<geo-location latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+<geo-location permission-status="{{permissionStatus}}" latitude="{{latitude}}" longitude="{{longitude}}"></geo-location>
+
+<ul>
+  <li>Permission status: [[permissionStatus]]</li>
+  <li>Latitude: [[latitude]]</li>
+  <li>Longitude: [[longitude]]</li>
+</ul>
 ```
 
 Continuous update the device geolocation values with high accuracy, and center Google Maps map and marker to the current location:
@@ -108,6 +114,15 @@ TODO: change the API key to your own.
         notify: true,
         readOnly: true,
         value: null
+      },
+
+      /**
+       * [Status](https://w3c.github.io/permissions/#status-of-a-permission) of Gelocation API permission.
+       */
+      permissionStatus: {
+        type: String,
+        readOnly: true,
+        notify: true
       }
 
     },
@@ -133,6 +148,19 @@ TODO: change the API key to your own.
      *   @param {Number} detail.latitude Latitude of the current position.
      *   @param {Number} detail.longitude Longitude of the current position.
      */
+
+    attached: function() {
+      if ('permissions' in navigator) {
+        navigator.permissions.query({
+          name: 'geolocation'
+        }).then(function(permissionStatus) {
+          this._setPermissionStatus(permissionStatus.state);
+          permissionStatus.onchange = function() {
+            this._setPermissionStatus(permissionStatus.state);
+          }.bind(this);
+        }.bind(this));
+      }
+    },
 
     detached: function () {
       this._clearWatch(this._watch);


### PR DESCRIPTION
* Add `permissionStatus` property that indicates whether Geolocation API [permission status](https://w3c.github.io/permissions/#status-of-a-permission) is `granted`, `denied` or `prompt`.
* Update code and descriptions of samples in `geo-location.html`, `demo/index.html` and `README.md` files.
* Add `api` and `permission` keywords to `bower.json` file.
* Fix a typo (change `Gelocation` to `Geolocation` everywhere).